### PR TITLE
Adapt scripts for releasing cve fix dek#8065

### DIFF
--- a/scripts/.util/tools.json
+++ b/scripts/.util/tools.json
@@ -1,5 +1,5 @@
 {
-  "createpackage": "v1.67.2",
-  "jam": "v2.6.0",
-  "pack": "v0.31.0"
+  "createpackage": "v1.69.0",
+  "jam": "v2.7.1",
+  "pack": "v0.33.2"
 }

--- a/scripts/.util/tools.sh
+++ b/scripts/.util/tools.sh
@@ -135,6 +135,13 @@ function util::tools::pack::install() {
 
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    local pack_config_enable_experimental
+    if [ -f "$(dirname "${BASH_SOURCE[0]}")/../options.json" ]; then
+      pack_config_enable_experimental="$(jq -r .pack_config_enable_experimental "$(dirname "${BASH_SOURCE[0]}")/../options.json")"
+    else
+      pack_config_enable_experimental="false"
+    fi
+
     tmp_location="/tmp/pack.tgz"
     curl_args=(
       "--fail"
@@ -157,6 +164,10 @@ function util::tools::pack::install() {
 
     tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
+
+    if [[ "${pack_config_enable_experimental}" == "true" ]]; then
+      "${dir}"/pack config experimental true
+    fi
 
     rm "${tmp_location}"
   else

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,6 +49,7 @@ function run::build() {
 
       GOOS=linux \
       CGO_ENABLED=0 \
+      GOARCH=amd64 \
         go build \
           -ldflags="-s -w" \
           -o "run" \

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -140,7 +140,7 @@ function buildpackage::create() {
   pack \
     buildpack package "${output}" \
       --path "${BUILD_DIR}/buildpack.tgz" \
-      --format file
+      --format image
 }
 
 main "${@:-}"


### PR DESCRIPTION
To fix https://github.com/plotly/dekn/issues/8065

upsteam main was already exempt of CVEs

We just need a release.

```
cnb/buildpacks/paketo-buildpacks_python-start/5.4.0/bin/run (gobinary)
======================================================================
Total: 3 (UNKNOWN: 2, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
```
